### PR TITLE
DTF-94: Restrict inherited secrets in reusable workflows

### DIFF
--- a/.github/workflows/build-and-test-reusable.yml
+++ b/.github/workflows/build-and-test-reusable.yml
@@ -19,8 +19,8 @@ on:
         type: boolean
         default: true
     secrets:
-      GITHUB_TOKEN:
-        description: 'The GITHUB_TOKEN for authenticating to the private NuGet registry'
+      TOKEN:
+        description: 'Github Token for authenticating to the private NuGet registry'
         required: true
 
 permissions:

--- a/.github/workflows/build-and-test-reusable.yml
+++ b/.github/workflows/build-and-test-reusable.yml
@@ -18,6 +18,10 @@ on:
         required: false
         type: boolean
         default: true
+    secrets:
+      GITHUB_TOKEN:
+        description: 'The GITHUB_TOKEN for authenticating to the private NuGet registry'
+        required: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description 

This pull request introduces a minor update to the workflow configuration, specifically related to secrets management. The change is to specify secrets inherited from the calling workflow instead of inheriting all secrets.

## Type of change
- Chore (CI)