### PR TITLE
fix: add missing api-key argument in NuGet push command

### DIFF
--- a/.github/workflows/publish-nuget-reusable.yaml
+++ b/.github/workflows/publish-nuget-reusable.yaml
@@ -63,4 +63,4 @@ jobs:
           NUGET_AUTH_TOKEN: ${{ secrets.nuget-api-key }}
           PACKAGE_NAME: ${{ inputs.package-name }}
         run: 
-          dotnet nuget push "./artifacts/${{ env.PACKAGE_NAME }}.*.nupkg" --source "https://api.nuget.org/v3/index.json" --skip-duplicate
+          dotnet nuget push "./artifacts/${{ env.PACKAGE_NAME }}.*.nupkg" --source "https://api.nuget.org/v3/index.json" --api-key ${{ secrets.nuget-api-key }} --skip-duplicate


### PR DESCRIPTION

## Description

This pull request makes a small update to the NuGet publish workflow. The change ensures that the NuGet API key is explicitly provided to the `dotnet nuget push` command, improving clarity and reliability of the authentication step.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactoring, adding tests, etc.)
- [ ] This change requires a documentation update

